### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/travipross/env2bws/releases/tag/v0.1.0) - 2025-02-23
+
+### Added
+
+- Initial Release
+
+### Other
+
+- Configure Github Actions for building and testing crate
+- Configure Github Actions for release-plz


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/travipross/env2bws/releases/tag/v0.1.0) - 2025-02-23

### Added

- Initial Release

### Other

- Configure Github Actions for building and testing crate
- Configure Github Actions for release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).