### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/travipross/env2bws/compare/v0.1.0...v0.1.1) - 2025-02-23
+
+### Added
+
+- Initial Release
+
+### Fixed
+
+- Use color output for help
+
+### Other
+
+- add test coverage for all modules
+- Configure Github Actions for building and testing crate
+- Configure Github Actions for release-plz
+
 ## [0.1.0](https://github.com/travipross/env2bws/releases/tag/v0.1.0) - 2025-02-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "env2bws"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env2bws"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "A tool to help import variables from .env files into Bitwarden Secrets Manager."


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/travipross/env2bws/compare/v0.1.0...v0.1.1) - 2025-02-23

### Added

- Initial Release

### Fixed

- Use color output for help

### Other

- add test coverage for all modules
- Configure Github Actions for building and testing crate
- Configure Github Actions for release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).