### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/travipross/env2bws/compare/v0.1.1...v0.1.2) - 2025-02-23
+
+### Added
+
+- expose as lib
+
+### Fixed
+
+- set keys to camelCase during import payload serialization
+- address lint errors from clippy
+
+### Other
+
+- populate missing docstrings throughout crate
+- update README with more detailed usage information
+- add test to assert validity of sample input and output in project
+- fix secret name in release-plz workflows
+- deny warnings in rust jobs
+- add check and lint jobs
+- pull pipeline secrets from BWS instead of storing in Github directly
+
 ## [0.1.1](https://github.com/travipross/env2bws/compare/v0.1.0...v0.1.1) - 2025-02-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "env2bws"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env2bws"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "A tool to help import variables from .env files into Bitwarden Secrets Manager."


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/travipross/env2bws/compare/v0.1.1...v0.1.2) - 2025-02-23

### Added

- expose as lib

### Fixed

- set keys to camelCase during import payload serialization
- address lint errors from clippy

### Other

- populate missing docstrings throughout crate
- update README with more detailed usage information
- add test to assert validity of sample input and output in project
- fix secret name in release-plz workflows
- deny warnings in rust jobs
- add check and lint jobs
- pull pipeline secrets from BWS instead of storing in Github directly
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).