### PR TITLE
chore: release v0.1.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,3 +33,9 @@ jobs:
         run: cargo check --verbose
       - name: Clippy
         run: cargo clippy --verbose
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Typos Checking
+        uses: crate-ci/typos@v1.29.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/travipross/env2bws/compare/v0.1.2...v0.1.3) - 2025-02-24
+
+### Other
+
+- fix various typos in README and module documentation
+- report typos
+
 ## [0.1.2](https://github.com/travipross/env2bws/compare/v0.1.1...v0.1.2) - 2025-02-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "env2bws"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env2bws"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "A tool to help import variables from .env files into Bitwarden Secrets Manager."

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ That would be parsed as a secret with the comment being stored as a "note":
 }
 ```
 
-### Assinging secrets to projects
+### Assigning secrets to projects
 
 As outlined in the [BWS documentation](https://bitwarden.com/help/import-secrets-data/#condition-an-import-file), secrets may optionally be assigned to projects in one of multiple ways:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-//! Module used for hadnling CLI behaviour with [`clap`]
+//! Module used for handling CLI behaviour with [`clap`]
 use std::path::PathBuf;
 
 use clap::{
@@ -95,7 +95,7 @@ mod cli_tests {
     #[test_case::test_case(&mut ["--help"] => matches Err(ErrorKind::DisplayHelp); "help when requested")]
     #[test_case::test_case(&mut ["-h"] => matches Err(ErrorKind::DisplayHelp); "help when requested short")]
     fn parse_args(args: &mut [&str]) -> Result<Cli, ErrorKind> {
-        // Combine test case args wiht full command string
+        // Combine test case args with full command string
         let mut cmd_and_args = vec!["first-arg-is-ignored-by-parser"];
         cmd_and_args.extend_from_slice(args);
 

--- a/src/dotenv.rs
+++ b/src/dotenv.rs
@@ -1,3 +1,4 @@
+//! Structured representation of `.env` files
 use std::{fs, ops::Deref, path::PathBuf};
 
 /// Represents a single environment variable with an optional comment

--- a/src/import_payload.rs
+++ b/src/import_payload.rs
@@ -1,3 +1,4 @@
+//! Structured representation of Bitwarden Secrets Manager import JSON format
 use crate::{DotEnvFile, EnvVar};
 use uuid::Uuid;
 


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/travipross/env2bws/compare/v0.1.2...v0.1.3) - 2025-02-24

### Other

- fix various typos in README and module documentation
- report typos
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).