### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/travipross/env2bws/compare/v0.1.2...v0.2.0) - 2025-02-24
+
+### Added
+
+- [**breaking**] remove cli module from public API of crate
+- add option to prevent overwriting existing output files unless overridden
+
+### Fixed
+
+- give better error message when input file can't be found
+
+### Other
+
+- publish build artifacts as release assets
+- fix various typos in README and module documentation
+- report typos in Github Actions
+
 ## [0.1.2](https://github.com/travipross/env2bws/compare/v0.1.1...v0.1.2) - 2025-02-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "env2bws"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env2bws"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A tool to help import variables from .env files into Bitwarden Secrets Manager."


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `env2bws` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod env2bws::cli, previously in file /tmp/.tmpZdQuwb/env2bws/src/cli.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  STYLES in file /tmp/.tmpZdQuwb/env2bws/src/cli.rs:10

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct env2bws::cli::ProjectAssignmentArgs, previously in file /tmp/.tmpZdQuwb/env2bws/src/cli.rs:63
  struct env2bws::cli::Cli, previously in file /tmp/.tmpZdQuwb/env2bws/src/cli.rs:21
  struct env2bws::Cli, previously in file /tmp/.tmpZdQuwb/env2bws/src/cli.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/travipross/env2bws/compare/v0.1.2...v0.2.0) - 2025-02-24

### Added

- [**breaking**] remove cli module from public API of crate
- add option to prevent overwriting existing output files unless overridden

### Fixed

- give better error message when input file can't be found

### Other

- publish build artifacts as release assets
- fix various typos in README and module documentation
- report typos in Github Actions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).