### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/travipross/env2bws/compare/v0.2.0...v0.2.1) - 2025-02-24
+
+### Other
+
+- enable build artifact publishing in CI
+
 ## [0.2.0](https://github.com/travipross/env2bws/compare/v0.1.2...v0.2.0) - 2025-02-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "env2bws"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env2bws"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "A tool to help import variables from .env files into Bitwarden Secrets Manager."


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/travipross/env2bws/compare/v0.2.0...v0.2.1) - 2025-02-24

### Other

- enable build artifact publishing in CI
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).