### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/travipross/env2bws/compare/v0.2.1...v0.2.2) - 2025-03-02
+
+### Added
+
+- break out functionality for parsing individual env var
+
+### Fixed
+
+- re-export EnvVar struct from dotenv crate to preserve API compatibility
+- break out functionality to parse from str
+
 ## [0.2.1](https://github.com/travipross/env2bws/compare/v0.2.0...v0.2.1) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "env2bws"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env2bws"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 description = "A tool to help import variables from .env files into Bitwarden Secrets Manager."


### PR DESCRIPTION



## 🤖 New release

* `env2bws`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/travipross/env2bws/compare/v0.2.1...v0.2.2) - 2025-03-02

### Added

- break out functionality for parsing individual env var

### Fixed

- re-export EnvVar struct from dotenv crate to preserve API compatibility
- break out functionality to parse from str
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).